### PR TITLE
changed routing from steaks table to profile

### DIFF
--- a/backend/services/progress-service/app/config.py
+++ b/backend/services/progress-service/app/config.py
@@ -38,6 +38,7 @@ class Settings(BaseSettings):
 
     SUPABASE_URL: str
     SUPABASE_SERVICE_ROLE_KEY: str
+    USER_PROFILE_SERVICE_URL: str = "http://user-profile-service:8000"
 
     class Config:
         env_file = ".env"

--- a/backend/services/progress-service/app/repositories/supabase_goals_repo.py
+++ b/backend/services/progress-service/app/repositories/supabase_goals_repo.py
@@ -5,6 +5,7 @@ from datetime import date, datetime, timezone
 import httpx
 
 from app.clients.supabase import supabase
+from app.config import settings
 from app.repositories.goals_repo import GoalsRepo
 
 
@@ -31,22 +32,16 @@ class SupabaseGoalsRepo(GoalsRepo):
         return int(rows[0].get("minutes", 0) or 0)
 
     async def get_streak(self, user_id: str) -> tuple[int, int]:
+        url = f"{settings.USER_PROFILE_SERVICE_URL}/profiles/me"
+        headers = {"X-User-Id": user_id}
         try:
-            rows = await supabase.get(
-                "streaks",
-                params={
-                    "select": "current_streak,longest_streak",
-                    "user_id": f"eq.{user_id}",
-                    "limit": "1",
-                },
-            )
-        except httpx.HTTPStatusError:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.get(url, headers=headers)
+            if resp.status_code >= 400:
+                return 0, 0
+            row = resp.json()
+        except Exception:
             return 0, 0
-
-        if not rows:
-            return 0, 0
-
-        row = rows[0]
         return int(row.get("current_streak", 0) or 0), int(row.get("longest_streak", 0) or 0)
 
     async def upsert_today_minutes(self, user_id: str, day: date, minutes: int) -> int:
@@ -94,17 +89,16 @@ class SupabaseGoalsRepo(GoalsRepo):
         return result
 
     async def upsert_streak(self, user_id: str, current_streak: int, longest_streak: int) -> None:
+        url = f"{settings.USER_PROFILE_SERVICE_URL}/profiles/me/streak"
+        headers = {"X-User-Id": user_id}
+        payload = {
+            "current_streak": max(0, int(current_streak)),
+            "longest_streak": max(0, int(longest_streak)),
+        }
         try:
-            await supabase.upsert(
-                "streaks",
-                [
-                    {
-                        "user_id": user_id,
-                        "current_streak": max(0, int(current_streak)),
-                        "longest_streak": max(0, int(longest_streak)),
-                        "updated_at": self._utc_now_iso(),
-                    }
-                ],
-            )
-        except httpx.HTTPStatusError:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.patch(url, headers=headers, json=payload)
+            if resp.status_code >= 400:
+                return
+        except Exception:
             return

--- a/backend/services/user-profile-service/app/repositories/profile_repo.py
+++ b/backend/services/user-profile-service/app/repositories/profile_repo.py
@@ -94,6 +94,13 @@ class ProfileRepo(Protocol):
         daily_pace: str | None = None,
         focus_areas: str | None = None,
     ) -> None: ...
+
+    async def update_streak(
+        self,
+        user_id: str,
+        current_streak: int,
+        longest_streak: int,
+    ) -> None: ...
     """
     Update onboarding-related fields for a user's profile.
 

--- a/backend/services/user-profile-service/app/repositories/supabase_profile_repo.py
+++ b/backend/services/user-profile-service/app/repositories/supabase_profile_repo.py
@@ -57,7 +57,7 @@ class SupabaseProfileRepo(ProfileRepo):
         rows = await supabase.get(
             "profiles",
             params={
-                "select": "id,username,onboarding_complete,email,native_language,full_name,learning_goal,feedback_tone,accent,daily_pace,skill_assess,focus_areas",
+                "select": "id,username,onboarding_complete,email,native_language,full_name,learning_goal,feedback_tone,accent,daily_pace,skill_assess,focus_areas,current_streak,longest_streak",
                 "id": f"eq.{user_id}",
                 "limit": "1",
             },
@@ -184,6 +184,21 @@ class SupabaseProfileRepo(ProfileRepo):
         await supabase.patch(
             "profiles",
             json=payload,
+            params={"id": f"eq.{user_id}"},
+        )
+
+    async def update_streak(
+        self,
+        user_id: str,
+        current_streak: int,
+        longest_streak: int,
+    ) -> None:
+        await supabase.patch(
+            "profiles",
+            json={
+                "current_streak": max(0, int(current_streak)),
+                "longest_streak": max(0, int(longest_streak)),
+            },
             params={"id": f"eq.{user_id}"},
         )
 

--- a/backend/services/user-profile-service/app/routers/profile.py
+++ b/backend/services/user-profile-service/app/routers/profile.py
@@ -36,6 +36,7 @@ from app.schemas.profile_schema import (
     ProfileInitRequest,
     ProfileInitResponse,
     ProfileDetailsUpdate,
+    ProfileStreakUpdate,
     ProfileReadResponse,
     ProfileOnboardingUpdate,
 )
@@ -152,6 +153,20 @@ async def patch_profile_details(
     await svc.update_profile_details(
         user_id=x_user_id or "",
         **body.dict(exclude_unset=True),
+    )
+    return ProfileInitResponse(ok=True)
+
+
+@router.patch("/profiles/me/streak")
+async def patch_profile_streak(
+    body: ProfileStreakUpdate,
+    x_user_id: str | None = Header(default=None, alias="X-User-Id"),
+    svc: ProfileService = Depends(get_profile_service),
+) -> ProfileInitResponse:
+    await svc.update_streak(
+        user_id=x_user_id or "",
+        current_streak=body.current_streak,
+        longest_streak=body.longest_streak,
     )
     return ProfileInitResponse(ok=True)
 

--- a/backend/services/user-profile-service/app/schemas/profile_schema.py
+++ b/backend/services/user-profile-service/app/schemas/profile_schema.py
@@ -94,6 +94,8 @@ class ProfileReadResponse(BaseModel):
     daily_pace: str | None = None
     skill_assess: str | None = None
     focus_areas: str | None = None
+    current_streak: int = 0
+    longest_streak: int = 0
 
 
 class ProfileOnboardingUpdate(BaseModel):
@@ -136,3 +138,8 @@ class ProfileDetailsUpdate(BaseModel):
         if value is None or not value.strip():
             raise ValueError("At least one learning goal is required")
         return value
+
+
+class ProfileStreakUpdate(BaseModel):
+    current_streak: int = 0
+    longest_streak: int = 0

--- a/backend/services/user-profile-service/app/services/profile_service.py
+++ b/backend/services/user-profile-service/app/services/profile_service.py
@@ -257,6 +257,21 @@ class ProfileService:
             focus_areas=cleaned_focus_areas,
         )
 
+    async def update_streak(
+        self,
+        user_id: str,
+        current_streak: int,
+        longest_streak: int,
+    ) -> None:
+        if not user_id:
+            bad_request("user_id missing")
+
+        await self.repo.update_streak(
+            user_id=user_id,
+            current_streak=max(0, int(current_streak)),
+            longest_streak=max(0, int(longest_streak)),
+        )
+
     async def delete_account(self, user_id: str) -> None:
         """
         Delete a user's account and profile.


### PR DESCRIPTION
Move streak storage from the dedicated streaks table to the profiles table. user-profile-service now selects current_streak and longest_streak on profile reads and exposes PATCH /profiles/me/streak to update them. progress-service stops reading/writing streaks in Supabase and instead calls the profile service (GET /profiles/me for reads, PATCH /profiles/me/streak for writes), with a new USER_PROFILE_SERVICE_URL setting for the base URL. Apply a DB migration adding current_streak and longest_streak on profiles before deploy.