### PR TITLE
Refactor solo practice page imports to include phoneme feedback widget

### DIFF
--- a/apps/mobile_interface/lib/src/features/solo_practice/pages/solo_practice_page.dart
+++ b/apps/mobile_interface/lib/src/features/solo_practice/pages/solo_practice_page.dart
@@ -14,8 +14,8 @@ import '../../courses/controllers/courses_controller.dart';
 import '../../courses/models/lesson.dart';
 import '../../progress/services/progress_service.dart';
 import '../controllers/solo_practice_controller.dart';
-import '../widgets/feedback_card.dart';
 import '../../../common/widgets/interactive_feedback_sentence.dart';
+import '../../../common/widgets/phoneme_feedback.dart';
 
 // ---------------------------------------------------------------------------
 // Page


### PR DESCRIPTION
- Removed the feedback card import and added the phoneme feedback widget to enhance the feedback mechanism in the solo practice feature.
- This change aligns with the ongoing improvements in the feedback system for better user experience.