### PR TITLE
Feat/sp ai feedback

### DIFF
--- a/apps/mobile_interface/lib/src/common/models/pronunciation_feedback.dart
+++ b/apps/mobile_interface/lib/src/common/models/pronunciation_feedback.dart
@@ -88,13 +88,18 @@ class WordFeedback {
 /// Despite the "Mock" suffix, this type is used both for:
 /// - Real JSON parsed from the pronunciation-feedback microservice.
 /// - Locally generated mock data when the API call fails or is unavailable.
+///
+/// [feedbackSessionId] is the opaque ID returned by /assess that can be
+/// passed to /pronunciation/ai-feedback to retrieve Gemini suggestions.
+/// It is null for mock/fallback results.
 class PronunciationFeedbackMock {
   final double accuracyScore;
   final double fluencyScore;
   final double completenessScore;
   final double? pronScore;
-  final String? summary; // optional tip
+  final String? summary;
   final List<WordFeedback> words;
+  final String? feedbackSessionId;
 
   const PronunciationFeedbackMock({
     required this.accuracyScore,
@@ -103,5 +108,6 @@ class PronunciationFeedbackMock {
     this.pronScore,
     this.summary,
     this.words = const [],
+    this.feedbackSessionId,
   });
 }

--- a/apps/mobile_interface/lib/src/common/widgets/microphone.dart
+++ b/apps/mobile_interface/lib/src/common/widgets/microphone.dart
@@ -158,8 +158,11 @@ class _MicrophoneState extends State<Microphone>
       await _recorder.start(
         const RecordConfig(
           encoder: AudioEncoder.wav,
-          sampleRate: 16000, // 16 kHz is guaranteed on all Android devices/emulators
-          numChannels: 1,    // mono — also what Azure Speech SDK expects
+          sampleRate: 16000,   // 16 kHz — Azure's optimal input rate for pronunciation assessment
+          numChannels: 1,      // mono — what Azure Speech SDK expects
+          autoGain: true,      // normalise volume across quiet/loud speakers
+          noiseSuppress: false, // keep raw signal — suppression targets fricatives (s/sh/f) which Azure needs
+          echoCancel: false,   // not needed; no playback during recording
         ),
         path: path,
       );

--- a/apps/mobile_interface/lib/src/features/solo_practice/controllers/solo_practice_controller.dart
+++ b/apps/mobile_interface/lib/src/features/solo_practice/controllers/solo_practice_controller.dart
@@ -57,6 +57,17 @@ class SoloPracticeController {
 
   PronunciationFeedbackMock? currentFeedback;
 
+  /// Gemini-generated suggestions keyed by card index.
+  /// Once populated for an index they are never cleared, enforcing the
+  /// "cannot generate again for the same item" requirement.
+  final Map<int, List<String>> _aiSuggestions = {};
+
+  /// True while a Gemini request is in-flight for the current card.
+  bool isLoadingAiSuggestions = false;
+
+  /// Set when the last AI suggestions request failed (cleared on next attempt).
+  bool aiSuggestionsFailed = false;
+
   /// All feedback results collected so far in this session (one per submitted card).
   List<PronunciationFeedbackMock> get sessionFeedbacks =>
       List.unmodifiable(_sessionFeedbacks);
@@ -141,11 +152,48 @@ class SoloPracticeController {
     return false;
   }
 
+  /// Returns the cached AI suggestions for [index], or null if none yet.
+  List<String>? aiSuggestionsFor(int index) => _aiSuggestions[index];
+
+  /// True when AI suggestions have already been generated for [index].
+  bool hasSuggestions(int index) => _aiSuggestions.containsKey(index);
+
+  /// Fetch Gemini suggestions for the current card and cache them.
+  /// No-op if suggestions already exist or no feedback / session ID is available.
+  Future<void> requestAiSuggestions(String? accessToken) async {
+    final feedback = currentFeedback;
+    final sessionId = feedback?.feedbackSessionId;
+    if (feedback == null || sessionId == null) return;
+    if (hasSuggestions(currentCardIndex)) return;
+
+    isLoadingAiSuggestions = true;
+    aiSuggestionsFailed = false;
+    try {
+      final suggestions = await fetchAiFeedback(
+        sessionId: sessionId,
+        feedback: feedback,
+        accessToken: accessToken,
+      );
+      if (suggestions != null && suggestions.isNotEmpty) {
+        _aiSuggestions[currentCardIndex] = suggestions;
+      } else {
+        aiSuggestionsFailed = true;
+      }
+    } catch (_) {
+      aiSuggestionsFailed = true;
+    } finally {
+      isLoadingAiSuggestions = false;
+    }
+  }
+
   /// Reset session to first card, clear feedback and accumulated results, mic to idle.
   void resetSession() {
     currentCardIndex = 0;
     micStateIndex = 0;
     currentFeedback = null;
     _sessionFeedbacks.clear();
+    _aiSuggestions.clear();
+    isLoadingAiSuggestions = false;
+    aiSuggestionsFailed = false;
   }
 }

--- a/apps/mobile_interface/lib/src/features/solo_practice/controllers/solo_practice_controller.dart
+++ b/apps/mobile_interface/lib/src/features/solo_practice/controllers/solo_practice_controller.dart
@@ -152,6 +152,13 @@ class SoloPracticeController {
     return false;
   }
 
+  /// Clears AI suggestions and error state for the current card so the button
+  /// reappears after a retry.
+  void clearAiSuggestionsForCurrentCard() {
+    _aiSuggestions.remove(currentCardIndex);
+    aiSuggestionsFailed = false;
+  }
+
   /// Returns the cached AI suggestions for [index], or null if none yet.
   List<String>? aiSuggestionsFor(int index) => _aiSuggestions[index];
 

--- a/apps/mobile_interface/lib/src/features/solo_practice/pages/solo_practice_page.dart
+++ b/apps/mobile_interface/lib/src/features/solo_practice/pages/solo_practice_page.dart
@@ -7,6 +7,7 @@ import 'package:provider/provider.dart';
 
 import '../../../app/constants.dart';
 import '../../../app/routes.dart';
+import '../../../common/models/pronunciation_feedback.dart';
 import '../../../common/pages/session_results_page.dart';
 import '../../../common/services/auth_service.dart';
 import '../../../common/widgets/microphone.dart';
@@ -582,6 +583,22 @@ class _SoloPracticePageState extends State<SoloPracticePage>
                                               ),
                                             ],
                                           ),
+                                          // ── AI Tips ──────────────────────────────
+                                          if (_isLowScore(_controller.currentFeedback!)) ...[
+                                            const SizedBox(height: AppSpacing.md),
+                                            _AiTipsSection(
+                                              cardIndex: _controller.currentCardIndex,
+                                              controller: _controller,
+                                              accessToken: () {
+                                                try {
+                                                  return context.read<AuthService>().accessToken;
+                                                } catch (_) {
+                                                  return null;
+                                                }
+                                              }(),
+                                              onStateChanged: () => setState(() {}),
+                                            ),
+                                          ],
                                           const SizedBox(height: AppSpacing.lg),
                                           // Try Again / Next actions.
                                           Row(
@@ -733,6 +750,188 @@ class _SoloPracticePageState extends State<SoloPracticePage>
             ),
 
           ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Low-score helper
+// ---------------------------------------------------------------------------
+
+/// Returns true when a result is below the threshold that triggers the AI tips
+/// button.  Mirrors the existing red-zone threshold used by [feedbackScoreColor].
+bool _isLowScore(PronunciationFeedbackMock f) {
+  final score = f.pronScore ??
+      (f.accuracyScore + f.fluencyScore + f.completenessScore) / 3;
+  return score < 60;
+}
+
+// ---------------------------------------------------------------------------
+// AI tips section
+// ---------------------------------------------------------------------------
+
+/// Shown inside the post-submission feedback card when the score is low.
+///
+/// Cycles through four states driven by local + controller state:
+/// - Button (default, session ID present)
+/// - Loading spinner (local `_loading` flag, avoids double-tap race)
+/// - Suggestions list (permanent once loaded)
+/// - Error message with retry (when controller reports failure)
+class _AiTipsSection extends StatefulWidget {
+  const _AiTipsSection({
+    required this.cardIndex,
+    required this.controller,
+    required this.accessToken,
+    required this.onStateChanged,
+  });
+
+  final int cardIndex;
+  final SoloPracticeController controller;
+  final String? accessToken;
+  final VoidCallback onStateChanged;
+
+  @override
+  State<_AiTipsSection> createState() => _AiTipsSectionState();
+}
+
+class _AiTipsSectionState extends State<_AiTipsSection> {
+  bool _loading = false;
+
+  Future<void> _request() async {
+    if (_loading) return;
+    setState(() => _loading = true);
+    await widget.controller.requestAiSuggestions(widget.accessToken);
+    if (mounted) {
+      setState(() => _loading = false);
+      widget.onStateChanged();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bodyStyle = GoogleFonts.publicSans(
+      color: AppColors.textSecondary,
+      fontSize: 13,
+      fontWeight: FontWeight.w500,
+    );
+
+    // Suggestions already loaded — render them permanently.
+    final suggestions = widget.controller.aiSuggestionsFor(widget.cardIndex);
+    if (suggestions != null && suggestions.isNotEmpty) {
+      return Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(AppSpacing.md),
+        decoration: BoxDecoration(
+          color: AppColors.primaryBg,
+          borderRadius: BorderRadius.circular(AppRadii.md),
+          border: Border.all(color: AppColors.border),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'AI Tips',
+              style: GoogleFonts.inter(
+                color: AppColors.textPrimary,
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                letterSpacing: 0.4,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            for (final s in suggestions) ...[
+              const SizedBox(height: 4),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.only(top: 3),
+                    child: Icon(
+                      Icons.arrow_right_rounded,
+                      size: 16,
+                      color: AppColors.accent,
+                    ),
+                  ),
+                  const SizedBox(width: 4),
+                  Expanded(child: Text(s, style: bodyStyle)),
+                ],
+              ),
+            ],
+          ],
+        ),
+      );
+    }
+
+    // Loading spinner — local flag prevents double-tap.
+    if (_loading) {
+      return Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const SizedBox(
+            width: 14,
+            height: 14,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              color: AppColors.accent,
+            ),
+          ),
+          const SizedBox(width: AppSpacing.sm),
+          Text('Getting AI tips…', style: bodyStyle),
+        ],
+      );
+    }
+
+    // Error state — show message and allow retry.
+    if (widget.controller.aiSuggestionsFailed) {
+      return Row(
+        children: [
+          Icon(Icons.error_outline_rounded, size: 15, color: AppColors.failure),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Text(
+              'Couldn\'t load tips.',
+              style: bodyStyle.copyWith(color: AppColors.failure),
+            ),
+          ),
+          TextButton(
+            onPressed: _request,
+            style: TextButton.styleFrom(
+              foregroundColor: AppColors.accent,
+              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
+              minimumSize: Size.zero,
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+            child: Text(
+              'Retry',
+              style: GoogleFonts.inter(fontSize: 13, fontWeight: FontWeight.w600),
+            ),
+          ),
+        ],
+      );
+    }
+
+    // Default: button (only when a session ID is available).
+    final sessionId = widget.controller.currentFeedback?.feedbackSessionId;
+    if (sessionId == null) return const SizedBox.shrink();
+
+    return SizedBox(
+      width: double.infinity,
+      child: OutlinedButton.icon(
+        onPressed: _request,
+        icon: const Icon(Icons.auto_awesome_rounded, size: 16),
+        label: Text(
+          'Get AI Tips',
+          style: GoogleFonts.inter(fontSize: 14, fontWeight: FontWeight.w600),
+        ),
+        style: OutlinedButton.styleFrom(
+          foregroundColor: AppColors.accent,
+          side: const BorderSide(color: AppColors.accent),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppRadii.md),
+          ),
+          padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
         ),
       ),
     );

--- a/apps/mobile_interface/lib/src/features/solo_practice/pages/solo_practice_page.dart
+++ b/apps/mobile_interface/lib/src/features/solo_practice/pages/solo_practice_page.dart
@@ -763,10 +763,14 @@ class _SoloPracticePageState extends State<SoloPracticePage>
 
 /// Returns true when a result is below the threshold that triggers the AI tips
 /// button.  Mirrors the existing red-zone threshold used by [feedbackScoreColor].
+/// Triggers the AI tips button when accuracy is below 88.
+///
+/// Accuracy alone is used rather than the composite (pronScore / average)
+/// because fluency and completeness measure flow and coverage — a smooth,
+/// complete but mispronounced attempt inflates the composite while accuracy
+/// still flags the real errors. 88 catches anything not solidly green.
 bool _isLowScore(PronunciationFeedbackMock f) {
-  final score = f.pronScore ??
-      (f.accuracyScore + f.fluencyScore + f.completenessScore) / 3;
-  return score < 75;
+  return f.accuracyScore < 88;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/mobile_interface/lib/src/features/solo_practice/pages/solo_practice_page.dart
+++ b/apps/mobile_interface/lib/src/features/solo_practice/pages/solo_practice_page.dart
@@ -213,6 +213,7 @@ class _SoloPracticePageState extends State<SoloPracticePage>
   void _onFeedbackRetry() {
     _clearRecording();
     setState(() {
+      _controller.clearAiSuggestionsForCurrentCard();
       _controller.setFeedback(null);
       _controller.retry(); // mic back to idle (state 0)
     });
@@ -765,7 +766,7 @@ class _SoloPracticePageState extends State<SoloPracticePage>
 bool _isLowScore(PronunciationFeedbackMock f) {
   final score = f.pronScore ??
       (f.accuracyScore + f.fluencyScore + f.completenessScore) / 3;
-  return score < 60;
+  return score < 75;
 }
 
 // ---------------------------------------------------------------------------
@@ -817,51 +818,10 @@ class _AiTipsSectionState extends State<_AiTipsSection> {
       fontWeight: FontWeight.w500,
     );
 
-    // Suggestions already loaded — render them permanently.
+    // Suggestions already loaded — render one-at-a-time carousel.
     final suggestions = widget.controller.aiSuggestionsFor(widget.cardIndex);
     if (suggestions != null && suggestions.isNotEmpty) {
-      return Container(
-        width: double.infinity,
-        padding: const EdgeInsets.all(AppSpacing.md),
-        decoration: BoxDecoration(
-          color: AppColors.primaryBg,
-          borderRadius: BorderRadius.circular(AppRadii.md),
-          border: Border.all(color: AppColors.border),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              'AI Tips',
-              style: GoogleFonts.inter(
-                color: AppColors.textPrimary,
-                fontSize: 13,
-                fontWeight: FontWeight.w700,
-                letterSpacing: 0.4,
-              ),
-            ),
-            const SizedBox(height: AppSpacing.xs),
-            for (final s in suggestions) ...[
-              const SizedBox(height: 4),
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.only(top: 3),
-                    child: Icon(
-                      Icons.arrow_right_rounded,
-                      size: 16,
-                      color: AppColors.accent,
-                    ),
-                  ),
-                  const SizedBox(width: 4),
-                  Expanded(child: Text(s, style: bodyStyle)),
-                ],
-              ),
-            ],
-          ],
-        ),
-      );
+      return _AiTipsCarousel(suggestions: suggestions);
     }
 
     // Loading spinner — local flag prevents double-tap.
@@ -934,6 +894,171 @@ class _AiTipsSectionState extends State<_AiTipsSection> {
           padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
         ),
       ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AI tips carousel — one sentence at a time, prev/next navigation
+// ---------------------------------------------------------------------------
+
+class _AiTipsCarousel extends StatefulWidget {
+  const _AiTipsCarousel({required this.suggestions});
+  final List<String> suggestions;
+
+  @override
+  State<_AiTipsCarousel> createState() => _AiTipsCarouselState();
+}
+
+class _AiTipsCarouselState extends State<_AiTipsCarousel>
+    with SingleTickerProviderStateMixin {
+  int _index = 0;
+  late AnimationController _fadeCtrl;
+  late Animation<double> _fade;
+
+  @override
+  void initState() {
+    super.initState();
+    _fadeCtrl = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 220),
+      value: 1.0,
+    );
+    _fade = CurvedAnimation(parent: _fadeCtrl, curve: Curves.easeOut);
+  }
+
+  @override
+  void dispose() {
+    _fadeCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _go(int next) async {
+    await _fadeCtrl.animateTo(0, duration: const Duration(milliseconds: 120));
+    if (!mounted) return;
+    setState(() => _index = next);
+    _fadeCtrl.forward();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final total = widget.suggestions.length;
+    final hasPrev = _index > 0;
+    final hasNext = _index < total - 1;
+
+    final labelStyle = GoogleFonts.inter(
+      color: AppColors.accent,
+      fontSize: 11,
+      fontWeight: FontWeight.w700,
+      letterSpacing: 0.8,
+    );
+    final tipStyle = GoogleFonts.publicSans(
+      color: AppColors.textPrimary,
+      fontSize: 14,
+      fontWeight: FontWeight.w500,
+      height: 1.45,
+    );
+    final navStyle = GoogleFonts.inter(
+      fontSize: 13,
+      fontWeight: FontWeight.w600,
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Header row: label + step indicator
+        Row(
+          children: [
+            Text('AI TIP', style: labelStyle),
+            const Spacer(),
+            Text(
+              '${_index + 1} / $total',
+              style: GoogleFonts.inter(
+                color: AppColors.textSecondary,
+                fontSize: 11,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+
+        // Animated tip text — fixed min-height to avoid layout jump
+        ConstrainedBox(
+          constraints: const BoxConstraints(minHeight: 52),
+          child: FadeTransition(
+            opacity: _fade,
+            child: Text(
+              widget.suggestions[_index],
+              style: tipStyle,
+            ),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+
+        // Dot indicators + prev/next controls
+        Row(
+          children: [
+            // Prev
+            AnimatedOpacity(
+              duration: const Duration(milliseconds: 180),
+              opacity: hasPrev ? 1.0 : 0.25,
+              child: GestureDetector(
+                onTap: hasPrev ? () => _go(_index - 1) : null,
+                child: Row(
+                  children: [
+                    Icon(Icons.arrow_back_ios_rounded,
+                        size: 13, color: AppColors.accent),
+                    const SizedBox(width: 2),
+                    Text('Prev', style: navStyle.copyWith(color: AppColors.accent)),
+                  ],
+                ),
+              ),
+            ),
+
+            const Spacer(),
+
+            // Dot strip
+            Row(
+              children: [
+                for (int i = 0; i < total; i++)
+                  AnimatedContainer(
+                    duration: const Duration(milliseconds: 220),
+                    curve: Curves.easeOut,
+                    margin: const EdgeInsets.symmetric(horizontal: 3),
+                    width: i == _index ? 16 : 6,
+                    height: 6,
+                    decoration: BoxDecoration(
+                      color: i == _index
+                          ? AppColors.accent
+                          : AppColors.border,
+                      borderRadius: BorderRadius.circular(3),
+                    ),
+                  ),
+              ],
+            ),
+
+            const Spacer(),
+
+            // Next
+            AnimatedOpacity(
+              duration: const Duration(milliseconds: 180),
+              opacity: hasNext ? 1.0 : 0.25,
+              child: GestureDetector(
+                onTap: hasNext ? () => _go(_index + 1) : null,
+                child: Row(
+                  children: [
+                    Text('Next', style: navStyle.copyWith(color: AppColors.accent)),
+                    const SizedBox(width: 2),
+                    Icon(Icons.arrow_forward_ios_rounded,
+                        size: 13, color: AppColors.accent),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
     );
   }
 }

--- a/apps/mobile_interface/lib/src/features/solo_practice/services/pronunciation_feedback_service.dart
+++ b/apps/mobile_interface/lib/src/features/solo_practice/services/pronunciation_feedback_service.dart
@@ -222,6 +222,9 @@ PronunciationFeedbackMock? _feedbackFromAssessmentJson(String body) {
     // Guard here (after building the word list) rather than early-returning
     // above, so we can still surface partial word data in a future extension.
     if (accuracy == null || fluency == null || completeness == null) return null;
+
+    final feedbackSessionId = map['feedback_session_id'] as String?;
+
     return PronunciationFeedbackMock(
       accuracyScore: accuracy,
       fluencyScore: fluency,
@@ -229,7 +232,69 @@ PronunciationFeedbackMock? _feedbackFromAssessmentJson(String body) {
       pronScore: pronScore,
       summary: 'Keep practicing for even clearer speech.',
       words: words,
+      feedbackSessionId: feedbackSessionId,
     );
+  } catch (_) {
+    return null;
+  }
+}
+
+/// Calls the API gateway `POST /pronunciation/ai-feedback` with the assessment
+/// data and session ID, and returns 2–3 Gemini-generated suggestion strings.
+///
+/// Returns null on any error so callers can handle gracefully.
+Future<List<String>?> fetchAiFeedback({
+  required String sessionId,
+  required PronunciationFeedbackMock feedback,
+  String? accessToken,
+}) async {
+  final uri = Uri.parse('$_gatewayBaseUrl/pronunciation/ai-feedback');
+
+  // Build the JSON body mirroring the backend AiFeedbackRequest schema.
+  final body = jsonEncode({
+    'feedback_session_id': sessionId,
+    'summary': {
+      'accuracy': feedback.accuracyScore,
+      'fluency': feedback.fluencyScore,
+      'completeness': feedback.completenessScore,
+      'pronScore': feedback.pronScore,
+    },
+    'words': [
+      for (final w in feedback.words)
+        {
+          'text': w.text,
+          'accuracy': w.accuracy,
+          'errorType': w.errorType,
+          'phonemes': [
+            for (final p in w.phonemes)
+              {
+                'symbol': p.symbol,
+                'accuracy': p.accuracy,
+                'user_said': p.userSaid,
+              },
+          ],
+        },
+    ],
+  });
+
+  try {
+    final headers = <String, String>{
+      'Content-Type': 'application/json',
+    };
+    if (accessToken != null && accessToken.isNotEmpty) {
+      headers['Authorization'] = 'Bearer $accessToken';
+    }
+
+    final response = await http
+        .post(uri, headers: headers, body: body)
+        .timeout(const Duration(seconds: 20));
+
+    if (response.statusCode != 200) return null;
+
+    final map = jsonDecode(response.body) as Map<String, dynamic>;
+    final suggestions = map['suggestions'] as List<dynamic>?;
+    if (suggestions == null) return null;
+    return suggestions.map((s) => s.toString()).toList();
   } catch (_) {
     return null;
   }

--- a/apps/mobile_interface/lib/src/features/solo_practice/widgets/feedback_card.dart
+++ b/apps/mobile_interface/lib/src/features/solo_practice/widgets/feedback_card.dart
@@ -17,46 +17,40 @@ Color feedbackScoreColor(double? accuracy) {
 /// Word-level color based on phoneme counts.
 ///
 ///  • No phoneme data              → [feedbackScoreColor] on [word.accuracy].
-///  • Any substitution             → failure red (wrong phoneme = real error,
-///                                   no grace regardless of count).
-///  • ≥ 2 low-accuracy (< 60)      → failure red.
-///  • 1 low-accuracy (< 60)        → action orange (grace: API noise on
-///                                   fricatives etc. ≠ broken word).
+///  • Any substitution             → failure red.
+///  • Any phoneme accuracy < 60    → failure red (clearly wrong, no grace).
 ///  • ≥ 2 borderline (60–84)       → action orange.
 ///  • else                         → success green.
 Color strictWordColor(WordFeedback word) {
   if (word.phonemes.isEmpty) return feedbackScoreColor(word.accuracy);
 
-  int lowCount = 0;
   int yellowCount = 0;
 
   for (final p in word.phonemes) {
     final isSubstitution = p.userSaid != null && p.userSaid != p.symbol;
     if (isSubstitution) return AppColors.failure;
     final accuracy = p.accuracy ?? 100.0;
-    if (accuracy < 60) {
-      lowCount++;
-    } else if (accuracy < 85) {
-      yellowCount++;
-    }
+    if (accuracy < 60) return AppColors.failure;
+    if (accuracy < 85) yellowCount++;
   }
 
-  if (lowCount >= 2) return AppColors.failure;
-  if (lowCount == 1) return AppColors.action;
   if (yellowCount >= 2) return AppColors.action;
   return AppColors.success;
 }
 
-/// Color for a "You said" phoneme chip — green only when the symbol matches
-/// AND accuracy is high (≥ 85). A substitution (different phoneme) is always red.
+/// Color for a "You said" phoneme chip.
+///
+///  • Known substitution (user_said ≠ symbol)     → always failure red.
+///  • user_said unknown + accuracy < 60            → failure red (clearly wrong).
+///  • user_said unknown + accuracy 60–84           → action orange.
+///  • Correct + accuracy ≥ 85                      → success green.
+///  • Correct + accuracy 60–84                     → action orange (not perfect).
 Color userSaidPhonemeColor(PhonemeFeedback p) {
   final said = p.userSaid ?? p.symbol;
-  final symbolMatches = said == p.symbol;
-  if (symbolMatches && (p.accuracy ?? 0) >= 85) return AppColors.success;
-  // Substitution: user produced a different phoneme — always failure red.
-  if (!symbolMatches) return AppColors.failure;
-  final c = feedbackScoreColor(p.accuracy);
-  return c == AppColors.success ? AppColors.action : c;
+  // Any visible mismatch between what the user said and the target → red.
+  if (said != p.symbol) return AppColors.failure;
+  // user_said was null or matched — color by accuracy.
+  return feedbackScoreColor(p.accuracy);
 }
 
 /// Shows the phoneme detail popup for a single [symbol].

--- a/backend/services/api-gateway/app/main.py
+++ b/backend/services/api-gateway/app/main.py
@@ -26,7 +26,7 @@ Notes:
 - Downstream services trust the Gateway and use X-User-Id for identity.
 """
 
-from fastapi import FastAPI, File, Form, Header, HTTPException, UploadFile
+from fastapi import FastAPI, File, Form, Header, HTTPException, Request, UploadFile
 from typing import Literal
 
 from pydantic import BaseModel, Field
@@ -1050,6 +1050,38 @@ async def proxy_pronunciation_assess(
             f"{settings.PRONUNCIATION_FEEDBACK_SERVICE_URL}/assess",
             files={"audio": (filename, content, "audio/wav")},
             data={"reference_text": reference_text},
+        )
+
+    if r.status_code >= 400:
+        try:
+            detail = r.json()
+        except Exception:
+            detail = r.text
+        raise HTTPException(status_code=r.status_code, detail=detail)
+
+    return r.json()
+
+
+@app.post("/pronunciation/ai-feedback")
+async def proxy_pronunciation_ai_feedback(
+    request: Request,
+    authorization: str | None = Header(default=None),
+):
+    """
+    Proxy AI feedback generation to the pronunciation-feedback service.
+
+    Accepts the assessment JSON (summary, words, feedback_session_id) and
+    returns 2–3 Gemini-generated improvement suggestions.
+    """
+    if not getattr(settings, "ALLOW_ANON_PRONUNCIATION_ASSESS", False):
+        verify_supabase_jwt(authorization)
+
+    body = await request.json()
+
+    async with httpx.AsyncClient(timeout=30) as client:
+        r = await client.post(
+            f"{settings.PRONUNCIATION_FEEDBACK_SERVICE_URL}/ai-feedback",
+            json=body,
         )
 
     if r.status_code >= 400:

--- a/backend/services/pronunciation-feedback/env.example
+++ b/backend/services/pronunciation-feedback/env.example
@@ -1,3 +1,7 @@
 # Azure Speech (Pronunciation Assessment). Get key and region from Azure portal.
 AZURE_SPEECH_KEY=
 AZURE_SPEECH_REGION=
+
+# Google Gemini (AI feedback). Get key from Google AI Studio.
+GEMINI_API_KEY=
+GEMINI_MODEL=gemini-2.5-flash

--- a/backend/services/pronunciation-feedback/main.py
+++ b/backend/services/pronunciation-feedback/main.py
@@ -5,37 +5,76 @@ Uses Azure Speech Services (scripted pronunciation assessment) to score a learne
 audio against reference text. Accepts WAV uploads and reference text; returns the
 full Azure pronunciation assessment JSON (scores, words, phonemes, etc.).
 
-TODO:
-- [X] clean the json for easy processing
-words: [{ text, wordScore, errorType, phonemes: [{ph, score}] }]
-- [X] color code word based off of wordScore
-- [] cache JSON output temporarily so we can keep results of the newest assessment
-- [] create error handling/pop up in dart page
-- [] map phoneme to 
-"""
-#future ideas as note to self: when user selects a word, have it play the audio of only the word so they can hear how it sounds.
+Prosody assessment is enabled for every /assess call. The prosody data is cached
+server-side (keyed by feedback_session_id) for use by /ai-feedback, but is never
+included in the /assess response sent to the app.
 
+/ai-feedback accepts the assessment JSON plus a feedback_session_id, looks up
+cached prosody, and calls Gemini to produce 2–3 actionable improvement sentences.
+"""
 
 import json
+import os
 import tempfile
+import uuid
 import wave
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from pprint import pprint
+from typing import Optional
 
 import azure.cognitiveservices.speech as speechsdk
 from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from google import genai
+from google.genai import types
+from pydantic import BaseModel
 from pydantic_settings import BaseSettings
 
-# Maximum allowed duration for uploaded audio (seconds). Longer clips are rejected.
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
 MAX_AUDIO_DURATION_SECONDS = 10
-# Locale used for Azure Speech; scripted assessment is en-US only for this service.
 LOCALE = "en-US"
+CACHE_TTL_MINUTES = 10
+
+# ---------------------------------------------------------------------------
+# In-memory prosody cache:  session_id → { "prosody": dict|None, "expires": datetime }
+# Entries are pruned on every /assess call to avoid unbounded growth.
+# ---------------------------------------------------------------------------
+_session_cache: dict[str, dict] = {}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _prune_cache() -> None:
+    """Remove expired entries from the in-memory session cache."""
+    now = datetime.now(tz=timezone.utc)
+    expired = [k for k, v in _session_cache.items() if v["expires"] < now]
+    for k in expired:
+        del _session_cache[k]
+
+
+def _extract_prosody(raw: dict) -> Optional[dict]:
+    """
+    Pull prosody scores out of the raw Azure JSON.
+
+    Azure places prosody inside PronunciationAssessment.Prosody when
+    enable_prosody_assessment() is active.  Returns None when absent.
+    """
+    nbest = (raw or {}).get("NBest") or []
+    best = nbest[0] if nbest else {}
+    pa = best.get("PronunciationAssessment") or {}
+    return pa.get("Prosody")
 
 
 def _clean_pronunciation_result(raw: dict) -> dict:
     """
     Transform the raw Azure pronunciation JSON into a compact, easy-to-consume
     structure focused on word- and phoneme-level scores.
+
+    Prosody is intentionally excluded from this output — it is cached
+    separately via _session_cache and used only by /ai-feedback.
 
     Output format:
     {
@@ -81,7 +120,6 @@ def _clean_pronunciation_result(raw: dict) -> dict:
         for p in w.get("Phonemes") or []:
             p_pa = p.get("PronunciationAssessment") or {}
             nbest_phonemes = p_pa.get("NBestPhonemes") or []
-            # Top entry in NBestPhonemes is what was detected (user said)
             user_said = nbest_phonemes[0].get("Phoneme") if nbest_phonemes else None
             phonemes_clean.append(
                 {
@@ -102,48 +140,55 @@ def _clean_pronunciation_result(raw: dict) -> dict:
     return {"summary": summary, "words": words_clean}
 
 
+# ---------------------------------------------------------------------------
+# Settings
+# ---------------------------------------------------------------------------
+
 class Settings(BaseSettings):
     """
     Application settings loaded from environment variables and optional .env file.
-    Used for Azure Speech credentials; empty defaults allow the app to start
-    and return 503 if /assess is called without config.
     """
     azure_speech_key: str = ""
     azure_speech_region: str = ""
+    gemini_api_key: str = ""
+    gemini_model: str = "gemini-2.5-flash"
 
     class Config:
         env_prefix = ""
-        # Load .env from the current working directory when the app starts.
         env_file = ".env"
 
 
 app = FastAPI(
     title="Pronunciation Feedback",
     description="Microservice for pronunciation assessment and feedback (Azure Speech, scripted, en-US).",
-    version="0.1.0",
+    version="0.2.0",
 )
 settings = Settings()
 
 
+# ---------------------------------------------------------------------------
+# Audio helpers
+# ---------------------------------------------------------------------------
+
 def get_wav_duration_seconds(path: Path) -> float:
-    """
-    Read the duration of a WAV file in seconds using the standard library wave module.
-    Raises if the file is not valid WAV or cannot be read.
-    """
+    """Read the duration of a WAV file in seconds using the standard library wave module."""
     with wave.open(str(path), "rb") as wav:
         frames = wav.getnframes()
         rate = wav.getframerate()
         return frames / float(rate)
 
 
-def run_pronunciation_assessment(audio_path: Path, reference_text: str) -> dict:
+# ---------------------------------------------------------------------------
+# Azure assessment
+# ---------------------------------------------------------------------------
+
+def run_pronunciation_assessment(audio_path: Path, reference_text: str) -> tuple[dict, Optional[dict]]:
     """
     Run Azure Speech scripted pronunciation assessment on an audio file.
 
-    Configures the Speech SDK with credentials, creates a recognizer with
-    pronunciation assessment (reference text, 0-100 grading, phoneme-level detail),
-    runs recognize_once(), and returns a cleaned JSON payload focused on
-    word- and phoneme-level scores.
+    Returns a tuple of:
+      - cleaned result dict (summary + words, no prosody)
+      - raw prosody dict (or None if absent / not supported)
     """
     speech_config = speechsdk.SpeechConfig(
         subscription=settings.azure_speech_key,
@@ -161,9 +206,10 @@ def run_pronunciation_assessment(audio_path: Path, reference_text: str) -> dict:
         granularity=speechsdk.PronunciationAssessmentGranularity.Phoneme,
         enable_miscue=True,
     )
-    # Request N-best spoken phonemes so we get NBestPhonemes (what the user said) per phoneme.
     pronunciation_config.nbest_phoneme_count = 5
-    # pronunciation_config.phoneme_alphabet = "IPA"
+    # Enable prosody — enriches the raw result used by Gemini, but is NOT
+    # forwarded to the app.
+    pronunciation_config.enable_prosody_assessment()
     pronunciation_config.apply_to(speech_recognizer)
 
     result = speech_recognizer.recognize_once()
@@ -183,9 +229,128 @@ def run_pronunciation_assessment(audio_path: Path, reference_text: str) -> dict:
         speechsdk.PropertyId.SpeechServiceResponse_JsonResult, "{}"
     )
     raw = json.loads(json_str)
-    pprint(raw)
-    return _clean_pronunciation_result(raw)
+    return _clean_pronunciation_result(raw), _extract_prosody(raw)
 
+
+# ---------------------------------------------------------------------------
+# Gemini AI feedback
+# ---------------------------------------------------------------------------
+
+def _build_feedback_prompt(
+    summary: dict,
+    words: list,
+    prosody: Optional[dict],
+    reference_text: Optional[str],
+) -> str:
+    """Build a prompt for Gemini based on the full pronunciation assessment data."""
+    assessment_payload: dict = {
+        "summary": summary,
+        "words": words,
+    }
+    if prosody:
+        assessment_payload["prosody"] = prosody
+
+    assessment_json = json.dumps(assessment_payload, indent=2)
+
+    reference_line = (
+        f'The learner was asked to say: "{reference_text}"\n\n'
+        if reference_text
+        else ""
+    )
+
+    return f"""You are an English pronunciation coach giving brief, encouraging feedback.
+
+A learner just completed a pronunciation assessment.
+{reference_line}Key for the JSON below:
+- Phoneme symbols are ARPAbet (e.g. "th", "dh", "ae", "iy"). "symbol" is the target phoneme; "user_said" is what the learner actually produced.
+- Scores are 0–100: ≥85 is good, 60–84 is borderline, <60 is poor.
+- errorType values: "None" = correct, "Omission" = word skipped, "Insertion" = extra word, "Mispronunciation" = wrong sounds.
+
+Full assessment JSON:
+{assessment_json}
+
+Based on this data, give exactly 2 to 3 short, actionable sentences of specific
+improvement advice tailored to the learner's weakest areas (low-accuracy phonemes,
+substitutions, omissions, fluency gaps, or prosody issues if present).
+Each sentence must be under 20 words. Be encouraging but direct.
+Do not repeat generic advice — address the actual errors by name (e.g. specific phonemes or words).
+Do not use markdown, bullet points, or numbering — just plain sentences.
+Return ONLY valid JSON in exactly this shape, with no extra text:
+{{"suggestions": ["sentence 1", "sentence 2", "sentence 3"]}}"""
+
+
+def generate_ai_feedback(
+    summary: dict,
+    words: list,
+    prosody: Optional[dict],
+    reference_text: Optional[str] = None,
+) -> list[str]:
+    """Call Gemini and return 2–3 feedback suggestion strings."""
+    api_key = settings.gemini_api_key
+    if not api_key:
+        raise HTTPException(status_code=503, detail="GEMINI_API_KEY is not configured")
+
+    client = genai.Client(api_key=api_key)
+    prompt = _build_feedback_prompt(summary, words, prosody, reference_text)
+
+    resp = client.models.generate_content(
+        model=settings.gemini_model,
+        contents=prompt,
+        config=types.GenerateContentConfig(response_mime_type="application/json"),
+    )
+
+    try:
+        text = resp.text.strip()
+        # Strip optional markdown fences
+        if text.startswith("```"):
+            text = text.split("```")[1]
+            if text.startswith("json"):
+                text = text[4:]
+        data = json.loads(text)
+        suggestions = data.get("suggestions") or []
+        if not suggestions:
+            raise ValueError("Empty suggestions list")
+        return [str(s) for s in suggestions[:3]]
+    except Exception as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Failed to parse Gemini response: {exc}",
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Request / response schemas
+# ---------------------------------------------------------------------------
+
+class PhonemeItem(BaseModel):
+    symbol: str
+    accuracy: Optional[float] = None
+    user_said: Optional[str] = None
+
+
+class WordItem(BaseModel):
+    text: str
+    accuracy: Optional[float] = None
+    errorType: Optional[str] = None
+    phonemes: list[PhonemeItem] = []
+
+
+class AssessmentSummary(BaseModel):
+    accuracy: Optional[float] = None
+    fluency: Optional[float] = None
+    completeness: Optional[float] = None
+    pronScore: Optional[float] = None
+
+
+class AiFeedbackRequest(BaseModel):
+    feedback_session_id: str
+    summary: AssessmentSummary
+    words: list[WordItem] = []
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
 
 @app.get("/")
 def root():
@@ -195,7 +360,7 @@ def root():
 
 @app.get("/health")
 def health():
-    """Health check endpoint (e.g. for Kubernetes or Docker healthchecks)."""
+    """Health check endpoint."""
     return {"status": "healthy"}
 
 
@@ -207,10 +372,9 @@ async def assess(
     """
     Assess pronunciation of uploaded audio against reference text.
 
-    Validates: reference_text non-empty, audio is WAV, duration <= 10s, Azure
-    config present. Writes upload to a temp file, runs Azure assessment, and
-    returns a compact JSON payload with overall scores plus per-word scores and
-    phoneme accuracies.
+    Returns the cleaned assessment JSON plus a feedback_session_id that can be
+    passed to /ai-feedback.  Prosody data is cached server-side under that ID
+    but is NOT included in this response.
     """
     if not reference_text or not reference_text.strip():
         raise HTTPException(status_code=400, detail="reference_text is required")
@@ -224,6 +388,9 @@ async def assess(
             status_code=503,
             detail="Azure Speech is not configured (AZURE_SPEECH_KEY, AZURE_SPEECH_REGION)",
         )
+
+    # Prune stale cache entries before adding new ones.
+    _prune_cache()
 
     content = await audio.read()
     suffix = Path(audio.filename).suffix or ".wav"
@@ -244,10 +411,45 @@ async def assess(
                 status_code=400,
                 detail=f"Audio duration {duration:.1f}s exceeds maximum {MAX_AUDIO_DURATION_SECONDS}s",
             )
-        return run_pronunciation_assessment(tmp_path, reference_text)
+
+        cleaned, prosody = run_pronunciation_assessment(tmp_path, reference_text)
+
+        # Cache prosody + reference text for use by /ai-feedback.
+        session_id = str(uuid.uuid4())
+        _session_cache[session_id] = {
+            "prosody": prosody,
+            "reference_text": reference_text.strip(),
+            "expires": datetime.now(tz=timezone.utc) + timedelta(minutes=CACHE_TTL_MINUTES),
+        }
+
+        return {**cleaned, "feedback_session_id": session_id}
+
     except HTTPException:
         raise
     except Exception as e:
         raise HTTPException(status_code=502, detail=f"Assessment failed: {e!s}")
     finally:
         tmp_path.unlink(missing_ok=True)
+
+
+@app.post("/ai-feedback")
+async def ai_feedback(body: AiFeedbackRequest):
+    """
+    Generate 2–3 actionable AI feedback sentences for a completed assessment.
+
+    Looks up prosody data from the in-memory cache using feedback_session_id
+    (best-effort — feedback is still generated if the session has expired).
+    Calls Gemini and returns the suggestions.
+    """
+    cached = _session_cache.get(body.feedback_session_id)
+    prosody: Optional[dict] = None
+    reference_text: Optional[str] = None
+    if cached and cached["expires"] > datetime.now(tz=timezone.utc):
+        prosody = cached.get("prosody")
+        reference_text = cached.get("reference_text")
+
+    summary_dict = body.summary.model_dump()
+    words_list = [w.model_dump() for w in body.words]
+
+    suggestions = generate_ai_feedback(summary_dict, words_list, prosody, reference_text)
+    return {"suggestions": suggestions}

--- a/backend/services/pronunciation-feedback/main.py
+++ b/backend/services/pronunciation-feedback/main.py
@@ -178,6 +178,35 @@ def get_wav_duration_seconds(path: Path) -> float:
         return frames / float(rate)
 
 
+# How much silence (in seconds) to prepend and append to the audio before
+# sending to Azure.  Azure's acoustic model scores each phoneme using
+# neighbouring-phoneme context (coarticulation); without any context the
+# first and last phonemes in an utterance are systematically under-scored.
+# 250 ms of silence on each side is enough to give the model that context
+# window without meaningfully affecting fluency or duration metrics.
+SILENCE_PAD_SECONDS = 0.25
+
+
+def pad_wav_with_silence(src: Path, dst: Path, pad_seconds: float = SILENCE_PAD_SECONDS) -> None:
+    """
+    Copy *src* WAV to *dst*, prepending and appending *pad_seconds* of silence.
+
+    The silence is generated as zero-valued PCM frames matching the source
+    file's sample width, channels, and frame rate, so Azure sees a valid,
+    consistently-formatted file.
+    """
+    with wave.open(str(src), "rb") as r:
+        params = r.getparams()
+        frames = r.readframes(r.getnframes())
+
+    pad_frame_count = int(params.framerate * pad_seconds)
+    silent_frames = b"\x00" * pad_frame_count * params.nchannels * params.sampwidth
+
+    with wave.open(str(dst), "wb") as w:
+        w.setparams(params)
+        w.writeframes(silent_frames + frames + silent_frames)
+
+
 # ---------------------------------------------------------------------------
 # Azure assessment
 # ---------------------------------------------------------------------------
@@ -194,42 +223,53 @@ def run_pronunciation_assessment(audio_path: Path, reference_text: str) -> tuple
         subscription=settings.azure_speech_key,
         region=settings.azure_speech_region,
     )
-    audio_config = speechsdk.audio.AudioConfig(filename=str(audio_path))
-    speech_recognizer = speechsdk.SpeechRecognizer(
-        speech_config=speech_config,
-        language=LOCALE,
-        audio_config=audio_config,
-    )
-    pronunciation_config = speechsdk.PronunciationAssessmentConfig(
-        reference_text=reference_text.strip(),
-        grading_system=speechsdk.PronunciationAssessmentGradingSystem.HundredMark,
-        granularity=speechsdk.PronunciationAssessmentGranularity.Phoneme,
-        enable_miscue=True,
-    )
-    pronunciation_config.nbest_phoneme_count = 5
-    # Enable prosody — enriches the raw result used by Gemini, but is NOT
-    # forwarded to the app.
-    pronunciation_config.enable_prosody_assessment()
-    pronunciation_config.apply_to(speech_recognizer)
 
-    result = speech_recognizer.recognize_once()
-    if result.reason != speechsdk.ResultReason.RecognizedSpeech:
-        raise HTTPException(
-            status_code=422,
-            detail={
-                "reason": str(result.reason),
-                "error": result.properties.get(
-                    speechsdk.PropertyId.SpeechServiceResponse_JsonResult, ""
-                )
-                or getattr(result, "error_details", None)
-                or "Speech recognition failed.",
-            },
+    # Pad the audio with silence so boundary phonemes (first / last in the
+    # utterance) receive the coarticulation context the acoustic model needs.
+    # Without this, Azure consistently under-scores them — an artefact of the
+    # model, not the learner's actual pronunciation.
+    padded_path = audio_path.with_suffix(".padded.wav")
+    pad_wav_with_silence(audio_path, padded_path)
+
+    try:
+        audio_config = speechsdk.audio.AudioConfig(filename=str(padded_path))
+        speech_recognizer = speechsdk.SpeechRecognizer(
+            speech_config=speech_config,
+            language=LOCALE,
+            audio_config=audio_config,
         )
-    json_str = result.properties.get(
-        speechsdk.PropertyId.SpeechServiceResponse_JsonResult, "{}"
-    )
-    raw = json.loads(json_str)
-    return _clean_pronunciation_result(raw), _extract_prosody(raw)
+        pronunciation_config = speechsdk.PronunciationAssessmentConfig(
+            reference_text=reference_text.strip(),
+            grading_system=speechsdk.PronunciationAssessmentGradingSystem.HundredMark,
+            granularity=speechsdk.PronunciationAssessmentGranularity.Phoneme,
+            enable_miscue=True,
+        )
+        pronunciation_config.nbest_phoneme_count = 5
+        # Enable prosody — enriches the raw result used by Gemini, but is NOT
+        # forwarded to the app.
+        pronunciation_config.enable_prosody_assessment()
+        pronunciation_config.apply_to(speech_recognizer)
+
+        result = speech_recognizer.recognize_once()
+        if result.reason != speechsdk.ResultReason.RecognizedSpeech:
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "reason": str(result.reason),
+                    "error": result.properties.get(
+                        speechsdk.PropertyId.SpeechServiceResponse_JsonResult, ""
+                    )
+                    or getattr(result, "error_details", None)
+                    or "Speech recognition failed.",
+                },
+            )
+        json_str = result.properties.get(
+            speechsdk.PropertyId.SpeechServiceResponse_JsonResult, "{}"
+        )
+        raw = json.loads(json_str)
+        return _clean_pronunciation_result(raw), _extract_prosody(raw)
+    finally:
+        padded_path.unlink(missing_ok=True)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/services/pronunciation-feedback/main.py
+++ b/backend/services/pronunciation-feedback/main.py
@@ -261,8 +261,8 @@ def _build_feedback_prompt(
     return f"""You are an English pronunciation coach giving brief, encouraging feedback.
 
 A learner just completed a pronunciation assessment.
-{reference_line}Key for the JSON below:
-- Phoneme symbols are ARPAbet (e.g. "th", "dh", "ae", "iy"). "symbol" is the target phoneme; "user_said" is what the learner actually produced.
+{reference_line}Key for the JSON below (use this to understand the data only — never output these codes):
+- Phoneme symbols are ARPAbet (e.g. "th", "dh", "ae", "iy"). "symbol" is the target phoneme; "user_said" is what the learner actually produced. Use these to understand what went wrong, but describe the issue in plain English in your output.
 - Scores are 0–100: ≥85 is good, 60–84 is borderline, <60 is poor.
 - errorType values: "None" = correct, "Omission" = word skipped, "Insertion" = extra word, "Mispronunciation" = wrong sounds.
 
@@ -272,9 +272,15 @@ Full assessment JSON:
 Based on this data, give exactly 2 to 3 short, actionable sentences of specific
 improvement advice tailored to the learner's weakest areas (low-accuracy phonemes,
 substitutions, omissions, fluency gaps, or prosody issues if present).
-Each sentence must be under 20 words. Be encouraging but direct.
-Do not repeat generic advice — address the actual errors by name (e.g. specific phonemes or words).
-Do not use markdown, bullet points, or numbering — just plain sentences.
+
+CRITICAL OUTPUT RULES — follow every one:
+- NEVER use ARPAbet or IPA symbols in your output (no "ae", "dh", "th", "iy", slashes, brackets, etc.).
+- Describe sounds using plain everyday English: "the 'uh' sound in 'cup'", "the soft 'th' in 'the'", "the long 'ee' in 'feet'".
+- Reference the actual words from the sentence the learner said, not abstract phoneme codes.
+- Each sentence must be under 20 words.
+- Be encouraging but direct.
+- Do not use markdown, bullet points, or numbering — just plain sentences.
+
 Return ONLY valid JSON in exactly this shape, with no extra text:
 {{"suggestions": ["sentence 1", "sentence 2", "sentence 3"]}}"""
 

--- a/backend/services/pronunciation-feedback/main.py
+++ b/backend/services/pronunciation-feedback/main.py
@@ -269,14 +269,24 @@ A learner just completed a pronunciation assessment.
 Full assessment JSON:
 {assessment_json}
 
-Based on this data, give exactly 2 to 3 short, actionable sentences of specific
-improvement advice tailored to the learner's weakest areas (low-accuracy phonemes,
-substitutions, omissions, fluency gaps, or prosody issues if present).
+Identify the ACTUAL errors in the data, then give exactly 2 to 3 short, actionable sentences addressing them.
 
-CRITICAL OUTPUT RULES — follow every one:
+Error priority — address in this order, stopping once you have 2–3 tips:
+1. Substitutions on stressed vowels or word-medial phonemes — these change how the word sounds most noticeably to a listener (e.g. saying "prEEshure" instead of "prEshure" because the vowel was wrong).
+2. Omissions: words with errorType "Omission" — skipped words.
+3. Other substitutions: user_said differs from symbol on consonants or unstressed positions.
+4. Low-accuracy phonemes: accuracy < 60 that are NOT substitutions.
+5. Weak final consonants or unstressed phonemes: only if no higher-priority errors remain — these are the least perceptually impactful.
+
+CRITICAL — errors only:
+- Only mention phonemes or words that have a real problem in the data (accuracy < 85, substitution, or omission).
+- Do NOT mention phonemes or words that scored ≥ 85 or have no errorType — do not invent problems.
+- Focus on the 2–3 worst issues maximum. Do not try to cover everything.
+
+CRITICAL OUTPUT RULES:
 - NEVER use ARPAbet or IPA symbols in your output (no "ae", "dh", "th", "iy", slashes, brackets, etc.).
-- Describe sounds using plain everyday English: "the 'uh' sound in 'cup'", "the soft 'th' in 'the'", "the long 'ee' in 'feet'".
-- Reference the actual words from the sentence the learner said, not abstract phoneme codes.
+- Describe sounds using plain everyday English: "the 'uh' sound in 'cup'", "the 'sh' in 'pressure'", "the long 'ee' in 'feet'".
+- Always reference the actual word from the sentence, not just the sound in isolation.
 - Each sentence must be under 20 words.
 - Be encouraging but direct.
 - Do not use markdown, bullet points, or numbering — just plain sentences.

--- a/backend/services/pronunciation-feedback/main.py
+++ b/backend/services/pronunciation-feedback/main.py
@@ -302,7 +302,10 @@ def generate_ai_feedback(
     resp = client.models.generate_content(
         model=settings.gemini_model,
         contents=prompt,
-        config=types.GenerateContentConfig(response_mime_type="application/json"),
+        config=types.GenerateContentConfig(
+            response_mime_type="application/json",
+            temperature=0.4,
+        ),
     )
 
     try:

--- a/backend/services/pronunciation-feedback/requirements.txt
+++ b/backend/services/pronunciation-feedback/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]>=0.32.0
 python-multipart>=0.0.9
 azure-cognitiveservices-speech>=1.34.0
 pydantic-settings>=2.0.0
+google-genai>=1.0.0


### PR DESCRIPTION
## Summary
Adds optional **AI tips** after a low-accuracy solo practice attempt. Tips are generated server-side with **Gemini** using the full assessment JSON, **ground truth text**, and **cached prosody** (prosody is not sent to the app). The client shows a **one-sentence-at-a-time carousel** with prev/next, **one generation per line item** (reset on **Try Again**), and **error + retry** if the request fails.

## Backend — `pronunciation-feedback`
- Enable **prosody** on Azure assessment; store **prosody + reference text** in a short-lived in-memory cache keyed by `feedback_session_id`.
- `POST /assess` response adds **`feedback_session_id`**; cleaned `summary` / `words` unchanged (no prosody in the response).
- New **`POST /ai-feedback`**: body `{ feedback_session_id, summary, words }` → `{ "suggestions": [...] }` (2–3 strings). Uses **Gemini** (`google-genai`), `temperature: 0.4`, strict JSON. Prompt rules: plain English (no ARPAbet in output), priority by error severity, no invented issues.
- **`requirements.txt`**: `google-genai`. **`env.example`**: `GEMINI_API_KEY`, `GEMINI_MODEL`.

## API gateway
- **`POST /pronunciation/ai-feedback`** → forwards JSON to pronunciation-feedback; same auth behaviour as **`POST /pronunciation/assess`**.

## Flutter — solo practice
- **`PronunciationFeedbackMock`**: optional `feedbackSessionId` from assess JSON.
- **`pronunciation_feedback_service`**: parse `feedback_session_id`; **`fetchAiFeedback(...)`** to gateway.
- **`SoloPracticeController`**: per-card suggestions map, loading + failure flags, **`requestAiSuggestions`**, **`clearAiSuggestionsForCurrentCard`** on retry.
- **`solo_practice_page`**: show **Get AI Tips** when **accuracy &lt; 88** and session id present; carousel; loading and error states.

## Configuration
- Pronunciation-feedback: set **`GEMINI_API_KEY`** (and optional **`GEMINI_MODEL`**). Gateway must point at the service (`PRONUNCIATION_FEEDBACK_SERVICE_URL`).

## How to test
- Record + submit in solo practice with **accuracy &lt; 88**; confirm **Get AI Tips** appears, tips load, carousel works, **Next** / **Try Again** behave as expected (tips cleared on retry for the same item).  
- With tips disabled or missing key: assess still works; clients without the new field ignore it.